### PR TITLE
Feature: 네트워크 매니저 추가

### DIFF
--- a/PleaseRecipe/Models/NetworkManager.swift
+++ b/PleaseRecipe/Models/NetworkManager.swift
@@ -44,13 +44,12 @@ final class NetworkManager {
     
     private func fetchRecipeData() {
         let recipeURL = "https://www.10000recipe.com/recipe/"
-        guard let url = URL(string: "\(recipeURL)7010582") else { return }
+        guard let url = URL(string: "\(recipeURL)7010580") else { return }
         let urlSession = URLSession(configuration: .default)
         
         urlSession.dataTask(with: url) { _, response, error in
             do {
-                let html = try String(contentsOf: url, encoding: .utf8)
-                guard error == nil else { return debugPrint(error!) }
+                guard error == nil else { return debugPrint(NetworkError.urlError) }
                 guard let response = response as? HTTPURLResponse else { return assertionFailure("응답 실패") }
                 let statusCode = response.statusCode
                 
@@ -58,6 +57,7 @@ final class NetworkManager {
                     return try self.errorMessage(statusCode)
                 }
                 
+                let html = try String(contentsOf: url, encoding: .utf8)
                 let doc: Document = try SwiftSoup.parse(html)
                 
                 try self.parsedData(for: doc)
@@ -152,6 +152,7 @@ extension NetworkManager {
         case redirectionError
         case clientError
         case serverError
+        case urlError
         case unknownError
         
         var debugDescription: String {
@@ -160,6 +161,7 @@ extension NetworkManager {
             case .redirectionError: "리다이렉션 에러"
             case .clientError: "클라이언트 에러"
             case .serverError: "서버 에러"
+            case .urlError: "URL 에러"
             case .unknownError: "알수없는 오류"
             }
         }


### PR DESCRIPTION
## ❗️ 코드를 추가 및 수정한 이유
- 만개의 레시피 웹 데이터를 사용하기 위한 기반 코드 작성
- 웹 크롤링 작업을 위한 swiftSoup 라이브러리 사용

## 🧾 작업 내용
- [x] 만개의 레시피 사이트의 임의의 데이터 가져오기 위한 NetworkManager 생성
- [x] NetworkManager 작동 테스트
- [x] 네트워크 에러발생 시 Error 메시지 만들기
  - 200~299: "네트워크 연결 성공"
  - 300~399: "리다이렉션 에러"
  - 400~499: "클라이언트 에러"
  - 500~500: "서버 에러"
  - 그 외: "알수없는 오류"
- [x] 파싱 에러발생 시 Error 메시지 만들기
- [x] 사용자가 접근할 필요성이 없다면 은닉화 작업 실시
  
## 🔥 작업 간 발생했던 어려움
- 만개의 레시피에서 사용하는 데이터를 원하는 데이터 형식으로 수정하는 작업이 까다로웠습니다.
  - 같은 재료라도 `[필수재료]`, `[재료]`로 이름만 달리하는 부분들이 있었습니다.
  - 또한 재료에 조미료가 포함되는 등 `정돈되지 않은 데이터`들이 많았습니다.
  - 따라서 앱 내에서 `enum을 사용`해 식재료와 조미료 또는 양념재료를 구분하는 것이 옳다고 판단됩니다.
  - 데이터를 추출한 뒤 enum에 포함되는 조미료에 대해서 별도로 처리하는 작업을 추가할 예정입니다.

## 📸 스크린샷(선택)
- 

## ❓ 기타
- 

## 🚪 Close issue
Close #3.
