### PR TITLE
Fix: FoodListCell의 UIStackView Layout 에러 해결

### DIFF
--- a/PleaseRecipe/UI/Views/FoodListView.swift
+++ b/PleaseRecipe/UI/Views/FoodListView.swift
@@ -25,6 +25,7 @@ final class FoodListView: UITableView {
     override init(frame: CGRect, style: UITableView.Style) {
         super.init(frame: frame, style: style)
         
+        delegate = self
         setupDataSource()
     }
     
@@ -63,5 +64,13 @@ final class FoodListView: UITableView {
         }
         
         diffableDataSource.apply(snapshot)
+    }
+}
+
+// MARK: - UITableViewDelegate
+
+extension FoodListView: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 120
     }
 }


### PR DESCRIPTION
## ❗️ 코드를 추가 및 수정한 이유
- FoodListCell의 UIStackView에서 발생하는 Layout 에러를 해결하기 위함.

## 🧾 작업 내용
- [x] cell에 대한 height 미지정에 따른 UIStackView Layout 에러 해결
  
## 🔥 작업 간 발생했던 어려움
- [ ] 

## 📸 스크린샷(선택)
![스크린샷 2023-10-22 오후 8 18 19](https://github.com/JUNY0110/PleaseRecipe/assets/98405970/0c834f86-b7a5-4cfc-a8b4-470df8bd49e3)


## ❓ 기타
- UIStackView의 크기를 기준으로 삼을 cell에 대한 높이가 지정되지 않아 발생한 문제입니다.
- 다른 View 작업 시에는 단순히 equalToSuperView()를 해도 이상이 없었으나, UIStackView 작업 시에는 이상이 발생하는 것이 다소 특이하다고 생각했습니다.

- 추가 참고자료: [Why UIStackView resize arranged subviews?](https://stackoverflow.com/questions/53532797/why-uistackview-resize-arranged-subviews)
  - 발생했던 에러와 조금 다른 내용이지만, 괜찮은 내용이라 추가합니다.
  - 해당 자료를 통해 UIStackView에 높이가 지정되어 있으면, UIStackView 자체 높이에 맞게 subView의 size를 조절하고,
  - UIStackView의 size가 정해져있지 않으면 subView의 크기에 따라 size를 조절한다는 것을 확인하였습니다.

## 🚪 Close issue
Close #15.
