### PR TITLE
Fix: Layout 및 Build warning

### DIFF
--- a/PleaseRecipe/UI/Views/Cells/FoodListCell.swift
+++ b/PleaseRecipe/UI/Views/Cells/FoodListCell.swift
@@ -40,6 +40,7 @@ final class FoodListCell: UITableViewCell {
     
     private let vStackView: UIStackView = {
         $0.axis = .vertical
+        $0.distribution = .fillProportionally
         $0.alignment = .top
         $0.spacing = 10
         return $0


### PR DESCRIPTION
## ❗️ 코드를 추가 및 수정한 이유
- Layout Warning을 해결하기 위함.
- Build Warning을 해결하기 위함.

## 🧾 작업 내용
- [x] Layout Warning: StackView distribution 추가
- [x] Build Warning: 
  - `SnapKit warning`: General -> Targets -> Build Settings -> iOS Deployment Target(10.0 -> 15.0)
  - `FireBase warning`: General -> Targets -> Build Settings -> Other Linker Flags (+ -Xlinker, -no_warn_duplicate_libraries) 
    <img width="600" alt="스크린샷 2023-11-10 오후 1 13 48" src="https://github.com/JUNY0110/RecipeForLivingAlone/assets/98405970/c2b96fae-4125-4ce7-8cd5-70b755322198">

## 🔥 작업 간 발생했던 어려움
- [x] Firebase warning의 경우, 임시 조치에 가까운 방법으로 추정됩니다.
  - [Firebase-iOS-sdk issue](https://github.com/firebase/firebase-ios-sdk/issues/11818)에서도 warning을 띄우지 않는 방법일 뿐, 실질적 해결책으로 보고되지는 않았습니다.
  - 또한 9월에 올라온 issue로 보아, 근래에 새롭게 생긴 warning으로 추정됩니다.

## 📸 스크린샷(선택)
- 

## ❓ 기타
- .gitignore에서 xcodeproj가 추가되어있는 상태로, build warning과 관련한 내용은 pr에 추가되어있지 않습니다.

## 🚪 Close issue
Close #24 #25 .
